### PR TITLE
TimetableManager methods to delete timetables

### DIFF
--- a/src/main/scala/ulisse/entities/timetable/DynamicTimetables.scala
+++ b/src/main/scala/ulisse/entities/timetable/DynamicTimetables.scala
@@ -33,9 +33,9 @@ object DynamicTimetables:
     def currentDelay: Option[Time] =
       (currentRoute, nextRoute) match
         case (Some((ds, _)), _) =>
-          effectiveTable.find(_._1 == ds).flatMap(_._2.departure) underflowSub table(ds).departure
+          effectiveTable.find(_._1 == ds).flatMap(_._2.departure) underflowSub table(ds).stationTime.departure
         case (_, Some((ds, _))) =>
-          effectiveTable.find(_._1 == ds).flatMap(_._2.arriving) underflowSub table(ds).arriving
+          effectiveTable.find(_._1 == ds).flatMap(_._2.arriving) underflowSub table(ds).stationTime.arriving
         case _ => effectiveTable.lastOption.flatMap(_._2.arriving) underflowSub arrivingTime
 
     def delayIn(station: Station): Option[Time] =
@@ -48,11 +48,11 @@ object DynamicTimetables:
 
     /** The next departure time */
     def nextDepartureTime: Option[ClockTime] =
-      calculateTimeWithDelay(nextRoute.flatMap(nr => table(nr._1).departure))
+      calculateTimeWithDelay(nextRoute.flatMap(nr => table(nr._1).stationTime.departure))
 
     /** The next arrival time */
     def nextArrivalTime: Option[ClockTime] =
-      calculateTimeWithDelay(currentRoute.flatMap(cr => table(cr._2).arriving))
+      calculateTimeWithDelay(currentRoute.flatMap(cr => table(cr._2).stationTime.arriving))
 
     private def calculateTimeWithDelay(time: Option[ClockTime]): Option[ClockTime] =
       if currentDelay.isDefined then time + currentDelay else time
@@ -114,7 +114,7 @@ object DynamicTimetables:
         )
 
       private def expectedDepartureTime: Option[ClockTime] =
-        nextRoute.flatMap(nr => table.find(_._1 == nr._1).flatMap(_._2.departure))
+        nextRoute.flatMap(nr => table.find(_._1 == nr._1).flatMap(_._2.stationTime.departure))
 
       extension (route: Option[(Station, Station)])
         private def updateTimeInfo(

--- a/src/main/scala/ulisse/infrastructures/view/timetable/model/TimetableGUIModel.scala
+++ b/src/main/scala/ulisse/infrastructures/view/timetable/model/TimetableGUIModel.scala
@@ -27,9 +27,9 @@ object TimetableGUIModel:
       t.table.map((station, times) =>
         TableEntryData(
           station.name,
-          times.arriving.optionString,
-          times.departure.optionString,
-          times.waitTime
+          times.stationTime.arriving.optionString,
+          times.stationTime.departure.optionString,
+          times.stationTime.waitTime
         )
       ).toList
 

--- a/src/test/scala/ulisse/applications/managers/TimetableManagerTest.scala
+++ b/src/test/scala/ulisse/applications/managers/TimetableManagerTest.scala
@@ -138,3 +138,30 @@ class TimetableManagerTest extends AnyFeatureSpec with GivenWhenThen:
       val requestResult = manager.remove(timetableABC.train.name, timetableABC.departureTime)
       Then("should be returned an error")
       requestResult should be(Left(TimetableNotFound(timetableABC.train.name)))
+
+    Scenario("Delete all timetables related to a train"):
+      Given("A manager with some timetable for a train")
+      val manager = TimetableManagers.TimetableManager(List(timetableABC, timetableBC))
+      When("I notify manager that a train is deleted")
+      val result = manager.trainDeleted(timetableABC.train)
+      Then("should be removed all timetables of train")
+      result should be(Right(TimetableManagers.TimetableManager(List())))
+
+    Scenario("Delete all timetables that contains a deleted station"):
+      Given("A manager with some timetable containing deleted station")
+      val manager = TimetableManagers.TimetableManager(List(timetableABC, timetableBC))
+      When("I notify manager that a station is deleted")
+      val result = manager.stationDeleted(stationA)
+      Then("should be removed all timetables that have deleted station")
+      result should be(Right(TimetableManagers.TimetableManager(List(timetableBC))))
+
+    Scenario("Delete all timetables that contains a deleted route"):
+      import ulisse.entities.route.Routes
+      val deletedRoute = Routes.Route(stationA, stationB, railAV_10.typeRoute, 1, 50)
+      deletedRoute in: route =>
+        Given("A manager with some timetable containing deleted route")
+        val manager = TimetableManagers.TimetableManager(List(timetableABC, timetableBC))
+        When("I notify manager that a route is deleted")
+        val result = manager.routeDeleted(route)
+        Then("should be removed all timetables that have deleted station")
+        result should be(Right(TimetableManagers.TimetableManager(List(timetableBC))))

--- a/src/test/scala/ulisse/entities/timetable/DynamicTimetableTest.scala
+++ b/src/test/scala/ulisse/entities/timetable/DynamicTimetableTest.scala
@@ -53,7 +53,7 @@ object DynamicTimetableTest:
   extension (tt: Timetable)
     def stationNr(n: Int): Option[(Station, TrainStationTime)] = tt match
       case dtt: DynamicTimetable => dtt.effectiveTable.drop(n).headOption
-      case _                     => tt.table.drop(n).headOption
+      case _                     => tt.table.map((st, info) => (st, info.stationTime)).drop(n).headOption
 
   extension (r: Option[(Station, Station)])
     def listify: Option[List[Station]] = r.map(t => List(t._1, t._2))
@@ -108,9 +108,9 @@ class DynamicTimetableTest extends AnyWordSpec with Matchers:
             ))
             newDtt.nextRoute.listify shouldBe Some(timetable1.table.keys.slice(1, 3))
             newDtt.currentDelay shouldBe ClockTime(0, 0).toOption
-            newDtt.nextDepartureTime shouldBe timetable1.table.drop(1).headOption.flatMap(_._2.departure)
+            newDtt.nextDepartureTime shouldBe timetable1.table.drop(1).headOption.flatMap(_._2.stationTime.departure)
             newDtt.currentRoute.listify shouldBe Some(timetable1.table.keys.take(2))
-            newDtt.nextArrivalTime shouldBe timetable1.table.drop(1).headOption.flatMap(_._2.arriving)
+            newDtt.nextArrivalTime shouldBe timetable1.table.drop(1).headOption.flatMap(_._2.stationTime.arriving)
             newDtt.completed shouldBe false
           case _ => fail()
 
@@ -128,10 +128,12 @@ class DynamicTimetableTest extends AnyWordSpec with Matchers:
             newDtt.nextRoute.listify shouldBe Some(timetable1.table.keys.slice(1, 3))
             newDtt.currentDelay shouldBe delay.toOption
             newDtt.nextDepartureTime shouldBe timetable1.table.drop(1).headOption.flatMap(
-              _._2.departure + delay.toOption
+              _._2.stationTime.departure + delay.toOption
             )
             newDtt.currentRoute.listify shouldBe Some(timetable1.table.keys.take(2))
-            newDtt.nextArrivalTime shouldBe timetable1.table.drop(1).headOption.flatMap(_._2.arriving + delay.toOption)
+            newDtt.nextArrivalTime shouldBe timetable1.table.drop(1).headOption.flatMap(
+              _._2.stationTime.arriving + delay.toOption
+            )
             newDtt.completed shouldBe false
           case _ => fail()
 
@@ -146,7 +148,7 @@ class DynamicTimetableTest extends AnyWordSpec with Matchers:
             ))
             newDtt.nextRoute.listify shouldBe Some(timetable1.table.keys.slice(1, 3))
             newDtt.currentDelay shouldBe ClockTime(0, 0).toOption
-            newDtt.nextDepartureTime shouldBe dynamicTimetable1.table(stationB).departure
+            newDtt.nextDepartureTime shouldBe dynamicTimetable1.table(stationB).stationTime.departure
             newDtt.currentRoute shouldBe None
             newDtt.completed shouldBe false
           case o => println(o); fail()
@@ -162,7 +164,7 @@ class DynamicTimetableTest extends AnyWordSpec with Matchers:
             ))
             newDtt.nextRoute shouldBe Some(stationB, stationC)
             newDtt.currentDelay shouldBe delay + delay
-            newDtt.nextDepartureTime shouldBe dynamicTimetable1.table(stationB).departure + delay + delay
+            newDtt.nextDepartureTime shouldBe dynamicTimetable1.table(stationB).stationTime.departure + delay + delay
             newDtt.currentRoute shouldBe None
             newDtt.completed shouldBe false
           case _ => fail()

--- a/src/test/scala/ulisse/entities/timetable/TimetableTest.scala
+++ b/src/test/scala/ulisse/entities/timetable/TimetableTest.scala
@@ -3,11 +3,10 @@ package ulisse.entities.timetable
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers.be
 import org.scalatest.matchers.should.Matchers.should
-import ulisse.Utils.TestUtility.in
 import ulisse.entities.route.Routes.RouteType.AV
 import ulisse.entities.route.Routes.RouteType
 import ulisse.entities.station.Station
-import ulisse.entities.timetable.Timetables.{toWaitTime, RailInfo, Timetable, TimetableBuilder}
+import ulisse.entities.timetable.Timetables.{toWaitTime, RailInfo, StationInfo, Timetable, TimetableBuilder}
 import ulisse.utils.Times.FluentDeclaration.h
 import ulisse.utils.Times.ClockTime
 import ulisse.entities.timetable.TestMockedEntities.*
@@ -27,9 +26,10 @@ class TimetableTest extends AnyFlatSpec:
       .stopsIn(stationD, waitTime = 10)(railAV_10)
       .arrivesTo(stationF)(railAV_10)
 
-  "timetable" should "provide list of stations where train stops and where it only transits" in:
+  "timetable" should "provide list of all stations, where train stops, where it only transits" in:
     AV1000TimeTable.stopStations should be(List(stationB, stationD))
     AV1000TimeTable.transitStations should be(List(stationC))
+    AV1000TimeTable.stations should be(List(stationA, stationB, stationC, stationD, stationF))
 
   "timetable" should "calculate arriving and departure time of each station where train arrives" in:
     val timeTableWithStops =
@@ -38,9 +38,9 @@ class TimetableTest extends AnyFlatSpec:
         .arrivesTo(stationC)(RailInfo(length = 15, typeRoute = AV))
 
     timeTableWithStops.table should be(ListMap(
-      stationA -> DepartureStationTime(h(9).m(0).toOption),
-      stationB -> AutoStationTime(arriving = h(9).m(2).toOption, waitTime = Some(5.toWaitTime)),
-      stationC -> ArrivingStationTime(arriving = h(9).m(10).toOption)
+      stationA -> StationInfo(None, DepartureStationTime(h(9).m(0).toOption)),
+      stationB -> StationInfo(Some(AV), AutoStationTime(arriving = h(9).m(2).toOption, waitTime = Some(5.toWaitTime))),
+      stationC -> StationInfo(Some(AV), ArrivingStationTime(arriving = h(9).m(10).toOption))
     ))
 
   "timetable" should "consider also station of transit in estimation of arriving time" in:
@@ -57,9 +57,9 @@ class TimetableTest extends AnyFlatSpec:
         .stopsIn(stationB, waitTime = 5)(railAV_10)
         .stopsIn(stationC, waitTime = 5)(railAV_10)
         .arrivesTo(stationD)(railAV_10)
-
+    val typeRoute = Some(AV)
     AV1000TimeTable.routes should be(List(
-      (stationA, stationB),
-      (stationB, stationC),
-      (stationC, stationD)
+      (stationA, stationB, typeRoute),
+      (stationB, stationC, typeRoute),
+      (stationC, stationD, typeRoute)
     ))


### PR DESCRIPTION
## Methods added to delete timetables

- [x] in case station is deleted all timetables with that station
- [x] in case route is deleted (find timetable with route (station-station) of RouteType)
- [x] in case train is deleted all timetables of given train

## !! Timetable was edited

It is added `StationInfo ` in order to keep track of type of Route

```scala
/** Station infos like `routeType` (to reach station) and `stationTime` */
 case class StationInfo(routeType: Option[RouteType], stationTime: StationTime)

```
